### PR TITLE
Remove unused http mocks

### DIFF
--- a/TestNetChallenge/StockBotServiceTests.cs
+++ b/TestNetChallenge/StockBotServiceTests.cs
@@ -1,7 +1,4 @@
-﻿using Moq;
-using System.Net;
 using NetChallenge.Services;
-using Moq.Protected;
 
 namespace TestNetChallenge
 {
@@ -14,25 +11,6 @@ namespace TestNetChallenge
             var stockCode = "AAPL.US";
             var csvResponse = "Symbol,Date,Time,Open,High,Low,Close,Volume\n" +
                               "AAPL.US,2024-12-09,22:00:14,241.83,247.24,241.75,246.75,44549049";
-
-            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
-            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
-
-            mockHttpMessageHandler
-                .Protected()
-                .Setup<Task<HttpResponseMessage>>(
-                    "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>()
-                )
-                .ReturnsAsync(new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent(csvResponse)
-                });
-
-            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
-            mockHttpClientFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
             var stockBotService = new StockBotService(null);
 


### PR DESCRIPTION
## Summary
- simplify `StockBotServiceTests` to directly test `ParseStockCsvResponse`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423c3521b883218e78f3ab3473e94a