### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prerequisites
   
 3. Install RabbitMQ
 
-  •	Install Erland/OTP
+  •	Install Erlang/OTP
 
   •	Install RabbitMQ and ensure the management plugin is enabled:	
   


### PR DESCRIPTION
## Summary
- fix Erland/OTP misspelling in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423c6799b48321a8f5537229ff0bcc