### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Chat Functionality
 
 5. StockBot Command
 
-  •	In any chatroom, users can type /stock=stock_code (e.g., /stock=aapl.us) to fetch stock quotes. This command can be use in any part of the message.
+  •	In any chatroom, users can type /stock=stock_code (e.g., /stock=aapl.us) to fetch stock quotes. This command can be used in any part of the message.
   
   •	The bot	 processes the request and replies with the stock's latest closing price e.g.,
 


### PR DESCRIPTION
## Summary
- fix grammar in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423c772d7483218276f28be567d455